### PR TITLE
express: add support for SSL

### DIFF
--- a/bin/www
+++ b/bin/www
@@ -6,7 +6,7 @@
 
 var app = require('../app');
 var debug = require('debug')('point-server:server');
-var http = require('http');
+var fs = require('fs');
 
 /**
  * Get port from environment and store in Express.
@@ -16,10 +16,24 @@ var port = normalizePort(process.env.PORT || '3000');
 app.set('port', port);
 
 /**
- * Create HTTP server.
+ * Create HTTP(S) server.
  */
 
-var server = http.createServer(app);
+var server
+if (process.env.SSL === 'true') {
+  // SSL enabled: create HTTPS server
+  var https = require('https');
+  server = https.createServer({
+    key: readRequiredFile(process.env.SSL_KEY || 'ssl/private.key.pem'),
+    cert: readRequiredFile(process.env.SSL_CERT || 'ssl/domain.cert.pem')
+  }, app);
+  debug('Created HTTPS server');
+} else {
+  // SSL disabled: create HTTP server
+  var http = require('http');
+  server = http.createServer(app);
+  debug('Created HTTP server');
+}
 
 /**
  * Listen on provided port, on all network interfaces.
@@ -47,6 +61,22 @@ function normalizePort(val) {
   }
 
   return false;
+}
+
+/**
+ * Read the content of a file or exit on failure
+ */
+
+function readRequiredFile(filename) {
+  try {
+    return fs.readFileSync(filename);
+  } catch (err) {
+    if (err.code === 'ENOENT')
+      console.error('Missing required file: ' + filename);
+    else
+      console.error('Failed to read file: ' + filename + '\n' + err.message);
+    process.exit(1);
+  }
 }
 
 /**


### PR DESCRIPTION
Allow using SSL to create HTTPS server. Three new environment variables possible:
```env
# Whether to use SSL or not. Default: false
SSL=true
# Path to the SSL private key file. Default: ssl/private.key.pem
SSL_KEY=ssl/private.key.pem
# Path to the SSL domain certificate file. Default: ssl/domain.cert.pem
SSL_CERT=ssl/domain.cert.pem
```
If `SSL` is `true`, the two other files are required to exist, otherwise the server will fail to start. If `false` (by default), no changes will be made and a classic HTTP server is created.
